### PR TITLE
feat: add playlist cover image endpoint

### DIFF
--- a/.changeset/thirty-chicken-check.md
+++ b/.changeset/thirty-chicken-check.md
@@ -1,0 +1,5 @@
+---
+'@spotifly/core': patch
+---
+
+Add support for [Get Playlist Cover Image](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-playlist-cover)

--- a/packages/core/src/models/params.ts
+++ b/packages/core/src/models/params.ts
@@ -95,6 +95,10 @@ export type VolumePercent = number & _;
  * false: Do not shuffle user's playback.
  */
 export type PlaybackShuffle = boolean & _;
+/**
+ * A Base64 encoded image for the playlist cover.
+ */
+export type Base64URL = string & _;
 
 export type Params = {
   additional_types: LiteralUnion<'track' | ' episode'>[];
@@ -138,5 +142,6 @@ export type UsersQueueResponse = {
 
   queue: (SpotifyApi.TrackObjectFull | SpotifyApi.EpisodeObjectFull)[];
 };
+export type GetPlaylistCoverImageResponse = SpotifyApi.ImageObject[];
 export type BooleanResponse = boolean[];
 export type VoidResponse = SpotifyApi.VoidResponse;

--- a/packages/core/src/models/playlists/index.ts
+++ b/packages/core/src/models/playlists/index.ts
@@ -14,6 +14,7 @@ import {
   PLAYLIST_ITEMS_LIMIT,
   removePlaylistItems,
   reorderPlaylistItems,
+  uploadCustomPlaylistCoverImage,
   USERS_PLAYLISTS_LIMIT,
 } from './playlists';
 
@@ -114,5 +115,10 @@ export default function Playlists(provider: AsyncProvider) {
      * @see {@link https://developer.spotify.com/documentation/web-api/reference/#/operations/get-playlist-cover Get Playlist Cover Image}
      */
     getPlaylistCoverImage: getPlaylistCoverImage(provider),
+    /**
+     * Replace the image used to represent a specific playlist.
+     * @see {@link https://developer.spotify.com/documentation/web-api/reference/#/operations/upload-custom-playlist-cover Add Custom Playlist Cover Image}
+     */
+    uploadCustomPlaylistCoverImage: uploadCustomPlaylistCoverImage(provider),
   };
 }

--- a/packages/core/src/models/playlists/playlists.ts
+++ b/packages/core/src/models/playlists/playlists.ts
@@ -1,6 +1,14 @@
 import { Method, transformResponse } from '../../request';
 import type { AsyncFnWithProvider } from '../../types';
-import type { CategoryId, Params, PlaylistId, Uri, UserId } from '../params';
+import type {
+  Base64URL,
+  CategoryId,
+  GetPlaylistCoverImageResponse,
+  Params,
+  PlaylistId,
+  Uri,
+  UserId,
+} from '../params';
 
 export const getPlaylist: AsyncFnWithProvider<
   SpotifyApi.SinglePlaylistResponse,
@@ -166,12 +174,28 @@ export const getCategoryPlaylists: AsyncFnWithProvider<
   );
 
 export const getPlaylistCoverImage: AsyncFnWithProvider<
-  SpotifyApi.ImageObject[],
+  GetPlaylistCoverImageResponse,
   PlaylistId
 > = provider => async playlistId =>
   transformResponse(
     await provider.request({
       method: Method.GET,
       url: `playlists/${playlistId}/images`,
+    })
+  );
+
+export const uploadCustomPlaylistCoverImage: AsyncFnWithProvider<
+  SpotifyApi.UploadCustomPlaylistCoverImageResponse,
+  PlaylistId,
+  Base64URL
+> = provider => async (playlistId, base64URL) =>
+  transformResponse(
+    await provider.request({
+      method: Method.PUT,
+      url: `playlists/${playlistId}/images`,
+      headers: {
+        'Content-Type': 'image/jpeg',
+      },
+      data: base64URL.replace(/^data:image\/jpeg;base64,/, ''),
     })
   );

--- a/packages/core/test/__snapshots__/index.test.ts.snap
+++ b/packages/core/test/__snapshots__/index.test.ts.snap
@@ -85,6 +85,7 @@ exports[`Lib matches snapshot 1`] = `
     "getUsersPlaylists": [Function],
     "removePlaylistItems": [Function],
     "reorderPlaylistItems": [Function],
+    "uploadCustomPlaylistCoverImage": [Function],
   },
   "Search": {
     "search": [Function],

--- a/packages/core/test/__snapshots__/lib.test.ts.snap
+++ b/packages/core/test/__snapshots__/lib.test.ts.snap
@@ -912,6 +912,22 @@ exports[`Playlists reorderPlaylistItems 1`] = `
 ]
 `;
 
+exports[`Playlists uploadCustomPlaylistCoverImage 1`] = `
+[
+  [
+    {
+      "data": "/9j/AAAAAAAAAAAAP/sABFEdW",
+      "headers": {
+        "Authorization": "Bearer token-xyz",
+        "Content-Type": "image/jpeg",
+      },
+      "method": "PUT",
+      "url": "playlists/id1/images",
+    },
+  ],
+]
+`;
+
 exports[`Search Search.get 1`] = `
 [
   [

--- a/packages/core/test/lib.test.ts
+++ b/packages/core/test/lib.test.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 import type { DataResponse as DR } from '../src';
 import * as Spotify from '../src';
-import type { BooleanResponse, VoidResponse } from '../src/models/params';
+import type {
+  BooleanResponse,
+  GetPlaylistCoverImageResponse,
+  VoidResponse,
+} from '../src/models/params';
 import {
   additional_types,
   country,
@@ -591,8 +595,18 @@ const tests: LibTestRunner = [
       {
         name: 'getPlaylistCoverImage',
         fn: () =>
-          assertReturns<DR<SpotifyApi.ImageObject[]>>(
+          assertReturns<DR<GetPlaylistCoverImageResponse>>(
             Client.Playlists.getPlaylistCoverImage(stringId)
+          ),
+      },
+      {
+        name: 'uploadCustomPlaylistCoverImage',
+        fn: () =>
+          assertReturns<DR<SpotifyApi.UploadCustomPlaylistCoverImageResponse>>(
+            Client.Playlists.uploadCustomPlaylistCoverImage(
+              stringId,
+              'data:image/jpeg;base64,/9j/AAAAAAAAAAAAP/sABFEdW'
+            )
           ),
       },
     ],

--- a/website/docs/packages/core.mdx
+++ b/website/docs/packages/core.mdx
@@ -112,7 +112,6 @@ Usually, a refresh token only needs to be generated once. You can [generate one 
 
 - ✅ - Fully supported
 - 〽️ - Partial support - work in progress
-- ❌ - Not yet suppoted - contributions are welcome!
 
 | Endpoint   | Support |
 | ---------- | ------- |
@@ -129,7 +128,6 @@ Usually, a refresh token only needs to be generated once. You can [generate one 
 | Tracks     | ✅      |
 | Users      | ✅      |
 
-- Playlists, missing: [Add Custom Playlist Cover Image](https://developer.spotify.com/documentation/web-api/reference/#/operations/upload-custom-playlist-cover). The docs are not clear about this endpoint's usage.
 - Playlists, missing: [Replace Playlist Items](https://developer.spotify.com/documentation/web-api/reference/#/operations/reorder-or-replace-playlists-tracks). I don't understand how this endpoint needs to be called in order to "replace" playlist items. Reordering items, however, is supported.
 
 <details>

--- a/website/docs/packages/core.mdx
+++ b/website/docs/packages/core.mdx
@@ -239,6 +239,7 @@ Usually, a refresh token only needs to be generated once. You can [generate one 
         <li>Playlists.getUsersPlaylists</li>
         <li>Playlists.removePlaylistItems</li>
         <li>Playlists.reorderPlaylistItems</li>
+        <li>Playlists.uploadCustomPlaylistCoverImage</li>
       </ul>
     </li>
     <li>


### PR DESCRIPTION
Add support for [Get Playlist Cover Image](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-playlist-cover).