### PR TITLE
feat: provide default exports and add error handling docs

### DIFF
--- a/.changeset/good-news-poke.md
+++ b/.changeset/good-news-poke.md
@@ -1,0 +1,15 @@
+---
+'@spotifly/core': minor
+---
+
+All named exports are now also available as properties of the default export. The following two examples are equivalent.
+
+```ts
+import { initialize, isError } from '@spotifly/core';
+```
+
+```ts
+import Spotifly from '@spotifly/core';
+Spotifly.initialize({...})
+Spotifly.isError({...})
+```

--- a/integration/core/core-mocking.test.ts
+++ b/integration/core/core-mocking.test.ts
@@ -1,4 +1,4 @@
-import * as Spotifly from '@spotifly/core';
+import Spotifly, { DataResponse, SpotifyClient } from '@spotifly/core';
 import { mockDeep } from 'jest-mock-extended';
 
 const audioFeatures: SpotifyApi.AudioFeaturesObject = {
@@ -22,8 +22,7 @@ const audioFeatures: SpotifyApi.AudioFeaturesObject = {
   valence: 0.428,
 };
 
-type MockResponse =
-  Spotifly.DataResponse<SpotifyApi.MultipleAudioFeaturesResponse>;
+type MockResponse = DataResponse<SpotifyApi.MultipleAudioFeaturesResponse>;
 
 const mockResponse = (length: number): MockResponse => {
   return {
@@ -35,7 +34,7 @@ const mockResponse = (length: number): MockResponse => {
   };
 };
 
-const mockSpotify = mockDeep<Spotifly.SpotifyClient>();
+const mockSpotify = mockDeep<SpotifyClient>();
 
 // Return a mocked client whenever the client is initialized
 jest.spyOn(Spotifly, 'initialize').mockReturnValue(mockSpotify);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,3 @@
-import { AuthProvider, AuthProviderOptions } from './provider';
-
 import Albums from './models/albums';
 import Artists from './models/artists';
 import Categories from './models/categories';
@@ -13,6 +11,9 @@ import Search from './models/search';
 import Shows from './models/shows';
 import Tracks from './models/tracks';
 import Users from './models/users';
+
+import { AuthProvider, AuthProviderOptions } from './provider';
+import { isError } from './request';
 
 export function initialize(authOptions: AuthProviderOptions) {
   const provider = new AuthProvider(authOptions);
@@ -34,7 +35,11 @@ export function initialize(authOptions: AuthProviderOptions) {
 }
 
 export type SpotifyClient = ReturnType<typeof initialize>;
-
-export { isError } from './request';
 export type { DataPromise, DataResponse } from './types';
 export type { AuthProviderOptions };
+export { isError };
+
+export default {
+  isError,
+  initialize,
+};

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,5 +1,8 @@
 import { AxiosError, AxiosResponse } from 'axios';
-import type { DataResponse, SpotifyError } from './types';
+import type {
+  DataResponse,
+  SpotifyRegularErrorObject as SpotifyError,
+} from './types';
 
 export enum Method {
   GET = 'GET',
@@ -17,8 +20,6 @@ export function transformResponse<T>(res: AxiosResponse<T>): DataResponse<T> {
 }
 
 export function isError(payload: unknown): payload is AxiosError<SpotifyError> {
-  return (
-    (payload as AxiosError<SpotifyError>).response?.data?.error?.message !==
-    undefined
-  );
+  const err = (payload as AxiosError<SpotifyError>).response?.data?.error;
+  return typeof err?.message === 'string' && typeof err?.status === 'number';
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,7 +12,7 @@ export type AsyncProvider = {
   request(req: AxiosRequestConfig): Promise<AxiosResponse>;
 };
 
-export type SpotifyError = {
+export type SpotifyRegularErrorObject = {
   error: {
     status: number;
     message: string;

--- a/packages/core/test/__snapshots__/index.test.ts.snap
+++ b/packages/core/test/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Lib matches snapshot 1`] = `
+exports[`Lib client methods 1`] = `
 {
   "Albums": {
     "checkAllUsersSavedAlbums": [Function],

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -1,7 +1,13 @@
 import { initialize } from '../src/index';
 
 describe('Lib', () => {
-  test('matches snapshot', () => {
+  test('client methods', () => {
     expect(initialize({ accessToken: '' })).toMatchSnapshot();
+  });
+  test('default and named exports', async () => {
+    const Spotifly = await import('../src/index');
+    const { initialize, isError } = await import('../src/index');
+    expect(Spotifly.default.initialize).toBe(initialize);
+    expect(Spotifly.default.isError).toBe(isError);
   });
 });

--- a/website/docs/packages/core.mdx
+++ b/website/docs/packages/core.mdx
@@ -38,7 +38,7 @@ npm install @spotifly/core @types/spotify-api
 ### Example
 
 ```ts
-import * as Spotifly from '@spotifly/core';
+import Spotifly from '@spotifly/core';
 
 const spotifyClient = Spotifly.initialize({
   accessToken: 'abc123',
@@ -81,9 +81,9 @@ Every Spotify client is created through a call to `initialize`. A client is boun
 1. **With a Spotify client id, client secret and refresh token** - This method will automatically generate an initial access token and refresh it when it's about to expire after 1 hour. This is great for apps that need to run independently.
 
 ```ts
-import { initialize } from '@spotifly/core';
+import Spotifly from '@spotifly/core';
 
-const spotifyClient = initialize({
+const spotifyClient = Spotifly.initialize({
   clientId: process.env.SPOTIFY_CLIENT_ID || '',
   clientSecret: process.env.SPOTIFY_CLIENT_SECRET || '',
   refreshToken: process.env.SPOTIFY_REFRESH_TOKEN || '',
@@ -93,7 +93,7 @@ const spotifyClient = initialize({
 2. **With a Spotify access token** - This method will simply attach the provided access token to requests to Spotify. No secrets are involved but requests may fail once the token has expired.
 
 ```ts
-import { initialize } from '@spotifly/core';
+import Spotifly from '@spotifly/core';
 
 const spotifyClient = Spotify.initialize({
   accessToken: 'abc123',
@@ -341,13 +341,51 @@ import type { DataResponse, DataPromise } from '@spotifly/core';
 
 ### Future
 
-Today's client supports the Spotify endpoints of tomorrow. The API features a `future.request` function that acts as an escape hatch for everything that is not yet or incorretly supported by this library. Requests made through `future.request` are always authenticated.
+Today's client supports the Spotify endpoints of tomorrow. The API features a `future.request` function that acts as an escape hatch for everything that is not yet or incorretly supported by this library. Requests made through `future.request` always include the Authorization header.
 
 ```ts
+import Spotifly from '@spotifly/core';
+
+const spotifyClient = Spotify.initialize({
+  accessToken: 'abc123',
+});
+
 await spotifyClient.future
   .request<MyResponseType>({ url: 'me/new-releases' })
   .then(console.log); // typeof MyResponseType
 ```
+
+### Error Handling
+
+The regular error object as defined by the Web API has the following shape:
+
+```ts
+type SpotifyRegularErrorObject = {
+  status: number;
+  message: string;
+};
+```
+
+You can use the `isError` helper to safely access the error object in case something goes wrong.
+
+```ts
+import Spotifly from '@spotifly/core';
+
+const spotifyClient = Spotify.initialize({
+  accessToken: 'abc123',
+});
+
+try {
+  await spotifyClient.Tracks.getTrack('thistrackdoesnotexist');
+} catch (e) {
+  if (Spotifly.isError(e)) {
+    console.log(e.response?.data.error.status); // 404
+    console.log(e.response?.data.error.message); // 'Not Found'
+  }
+}
+```
+
+[See Web API / Response Schema](https://developer.spotify.com/documentation/web-api/).
 
 ## Convenience Methods
 
@@ -365,9 +403,15 @@ Non-convenience/ordinary methods do not have such logic. They do not check or ch
 
 The following example returns all of a user's saved tracks in a flat array. Convenience methods have a different signature: **They are curried and return a function which optionally accepts a callback**. Each time a new chunk of items is fetched, the response wrapped in a `DataResponse<T>` is passed to the callback as the only argument.
 
-Asynchronous callbacks are allowed. Their return values are ignored.
+If the callback returns a promise, it is awaited. The eventually returned value is ignored.
 
 ```ts
+import Spotifly, { DataResponse } from '@spotifly/core';
+
+const spotifyClient = Spotify.initialize({
+  accessToken: 'abc123',
+});
+
 const allTracks = await spotifyClient.Tracks.getAllUsersSavedTracks()(
   async response => {
     // DataResponse<SpotifyApi.UsersSavedTracksResponse>
@@ -380,19 +424,26 @@ const allTracks = await spotifyClient.Tracks.getAllUsersSavedTracks()(
 
 You can do pretty much anything with the chunk - e.g., log something to the console or send the items somewhere else.
 
-Convenience methods simply wrap their ordinary counterpart and resolve all responses in a single array. This is reflected in their return types: If the ordinary methods returns `DataResponse<T>`, the convenience method returns `Array<DataResponse<T>>`
+Convenience methods simply wrap their ordinary counterpart and resolve all responses in a single array. This is reflected in their return types: If the ordinary methods returns `DataResponse<T>`, the convenience method returns `Array<DataResponse<T>>`:
 
 ```ts
-const allTracks: DataResponse<SpotifyApi.UsersSavedTracksResponse>[] =
+import Spotifly, { DataResponse } from '@spotifly/core';
+
+const spotifyClient = Spotify.initialize({
+  accessToken: 'abc123',
+});
+
+type UserTracks = DataResponse<SpotifyApi.UsersSavedTracksResponse>;
+
+const allTracks: UserTracks[] =
   await spotifyClient.Tracks.getAllUsersSavedTracks()();
 
-const someTracks: DataResponse<SpotifyApi.UsersSavedTracksResponse> =
-  await spotifyClient.Tracks.getUsersSavedTracks();
+const someTracks: UserTracks = await spotifyClient.Tracks.getUsersSavedTracks();
 ```
 
 ## Testing Recipes
 
-The core library can be mocked nicely with [`Jest`](https://jestjs.io/) and the TypeScript-friendly [`jest-mock-extended`](https://www.npmjs.com/package/jest-mock-extended) extension. The following examples assume you have already setup `Jest` accordingly for your project.
+The core library can be mocked nicely with [`Jest`](https://jestjs.io/) and the TypeScript-friendly [`jest-mock-extended`](https://www.npmjs.com/package/jest-mock-extended) extension. The following examples assume you have already installed `@types/spotify-api` and setup `Jest` accordingly for your project.
 
 1. Install `jest-mock-extended`.
 
@@ -403,7 +454,7 @@ npm install -D jest-mock-extended
 2. Mock whatever methods you are using using the `mockDeep` helper and inject this object whenever `initialize` is called in the implementation. Using the types from `@types/spotify-api`, it's very easy to create solid mock responses.
 
 ```ts
-import * as Spotifly from '@spotifly/core';
+import Spotifly, { DataResponse, SpotifyClient } from '@spotifly/core';
 import { mockDeep } from 'jest-mock-extended';
 
 const audioFeatures: SpotifyApi.AudioFeaturesObject = {
@@ -427,8 +478,7 @@ const audioFeatures: SpotifyApi.AudioFeaturesObject = {
   valence: 0.428,
 };
 
-type MockResponse =
-  Spotifly.DataResponse<SpotifyApi.MultipleAudioFeaturesResponse>;
+type MockResponse = DataResponse<SpotifyApi.MultipleAudioFeaturesResponse>;
 
 const mockResponse = (length: number): MockResponse => {
   return {
@@ -440,7 +490,7 @@ const mockResponse = (length: number): MockResponse => {
   };
 };
 
-const mockSpotify = mockDeep<Spotifly.SpotifyClient>();
+const mockSpotify = mockDeep<SpotifyClient>();
 
 // Return a mocked client whenever the client is initialized
 jest.spyOn(Spotifly, 'initialize').mockReturnValue(mockSpotify);


### PR DESCRIPTION
- Provide both named and a default export. The default export should include all named exports. Does not apply to exported types.
- Add docs for `isError` .