### PR TITLE
feat: auto-authentication from config file

### DIFF
--- a/.changeset/cold-eagles-sort.md
+++ b/.changeset/cold-eagles-sort.md
@@ -2,4 +2,4 @@
 '@spotifly/cli': minor
 ---
 
-Read from a (global) config to enable auto-authentication
+Read from a (global) config to enable auto-authentication. [Docs](https://spotifly.nougat.dev/docs/command-line#configuration-and-auto-authentication).

--- a/.changeset/cold-eagles-sort.md
+++ b/.changeset/cold-eagles-sort.md
@@ -1,0 +1,5 @@
+---
+'@spotifly/cli': minor
+---
+
+Read from a (global) config to enable auto-authentication

--- a/.changeset/forty-games-bow.md
+++ b/.changeset/forty-games-bow.md
@@ -1,0 +1,5 @@
+---
+'@spotifly/core': patch
+---
+
+Refine exports related to `AuthProvider`. The class and its types are now available under `@spotifly/core/provider`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,13 +32,18 @@
   ],
   "dependencies": {
     "@spotifly/auth-token": "workspace:^",
+    "@spotifly/core": "workspace:^",
     "@spotifly/library": "workspace:^",
-    "@spotifly/utils": "workspace:^"
+    "@spotifly/utils": "workspace:^",
+    "ini": "^4.1.0"
   },
   "engines": {
     "node": ">=14"
   },
   "publishConfig": {
     "directory": "_release/package"
+  },
+  "devDependencies": {
+    "@types/ini": "^1.3.31"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -46,7 +46,7 @@ For docs & help, visit ${pkg.homepage}
     // Packages that requrie authentication will have a --token argument
     return callback([...argv, '--token', accessToken]);
   } catch (err) {
-    console.error(err);
+    console.error((err as Error).message);
   }
 };
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -40,6 +40,7 @@ For docs & help, visit ${pkg.homepage}
   try {
     const credentials = credentialsFromConfig(spotiflyConfig, profile);
     const accessToken = await getAccessToken(credentials);
+    // Packages that requrie authentication will have a --token argument
     return callback([...argv, '--token', accessToken]);
   } catch (err) {
     console.error(err);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,7 @@ export type Invoke = {
 
 const invoke = async (
   argv: string[],
+  withAutoAuth: boolean,
   { callback, help, pkg }: Invoke
 ): Promise<unknown> => {
   if (argv.includes('--help') || argv.includes('-h')) {
@@ -33,10 +34,12 @@ For docs & help, visit ${pkg.homepage}
     return;
   }
 
+  if (!withAutoAuth) return callback(argv);
+
   const spotiflyConfig = readConfig();
   if (!spotiflyConfig) return callback(argv);
-  const profile = profileFromArgv(argv);
 
+  const profile = profileFromArgv(argv);
   try {
     const credentials = credentialsFromConfig(spotiflyConfig, profile);
     const accessToken = await getAccessToken(credentials);
@@ -68,20 +71,26 @@ export const run = async (): Promise<unknown> => {
       )}
 - ${ownPackage.description}
 
-Available commands: ${colors.green(`
-- auth
-- library
+Available subcommands: ${colors.green(`
+* auth
+* library
 `)}
+
+Optional flags:
+${colors.yellow('* --profile')} [string]
+  The profile in your Spotifly config file to use for authentication.
+  Defaults to 'default'.
+
 For docs & help, visit ${ownPackage.homepage}`);
       return;
     case 'auth':
-      return invoke(args, {
+      return invoke(args, false, {
         callback: authCli.callback,
         help: authCli.help,
         pkg: authCli.pkg,
       });
     case 'library':
-      return invoke(args, {
+      return invoke(args, true, {
         callback: libraryCli.callback,
         help: libraryCli.help,
         pkg: libraryCli.pkg,

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -29,12 +29,12 @@ export function credentialsFromConfig(
 ): RefreshTokenConfig {
   const parsedConfig = ini.parse(config);
   if (!parsedConfig[profile]) {
-    throw new Error(`Profile "${profile}" not found in config`);
+    throw new Error(`Profile "${profile}" does not exist`);
   }
   const { spt_client_id, spt_client_secret, spt_refresh_token } =
     parsedConfig[profile];
   if (!spt_client_id || !spt_client_secret || !spt_refresh_token) {
-    throw new Error('Missing Spotify credentials');
+    throw new Error('Missing or invalid Spotify credentials');
   }
   return {
     clientId: spt_client_id,

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -1,0 +1,64 @@
+import { AuthProvider, RefreshTokenConfig } from '@spotifly/core/provider';
+import { existsSync, readFileSync } from 'fs';
+import ini from 'ini';
+import os from 'os';
+import { join } from 'path';
+
+enum ConfigLocation {
+  Home,
+  Current,
+  None,
+}
+
+const configFileName = '.spotifly';
+
+export function profileFromArgv(argv: string[]): string {
+  const withProfile = argv.indexOf('--profile');
+  if (withProfile === -1) return 'default';
+  return argv[withProfile + 1];
+}
+
+function configLocaton(): ConfigLocation {
+  return existsSync(join(process.cwd(), configFileName))
+    ? ConfigLocation.Current
+    : existsSync(join(os.homedir(), configFileName))
+    ? ConfigLocation.Home
+    : ConfigLocation.None;
+}
+
+export function readConfig(): string | null {
+  const configLoc = configLocaton();
+  if (configLoc === ConfigLocation.None) return null;
+
+  // Fallback dir is home
+  let path = join(os.homedir(), configFileName);
+  // Current directory overrides
+  if (configLoc === ConfigLocation.Current) {
+    path = join(process.cwd(), configFileName);
+  }
+  return readFileSync(path, 'utf-8');
+}
+
+export function credentialsFromConfig(
+  config: string,
+  profile: string
+): RefreshTokenConfig {
+  const parsedConfig = ini.parse(config);
+  if (!parsedConfig[profile]) {
+    throw new Error(`Profile "${profile}" not found in config`);
+  }
+  const { spt_client_id, spt_client_secret, spt_refresh_token } =
+    parsedConfig[profile];
+  if (!spt_client_id || !spt_client_secret || !spt_refresh_token) {
+    throw new Error('Missing Spotify credentials');
+  }
+  return {
+    clientId: spt_client_id,
+    clientSecret: spt_client_secret,
+    refreshToken: spt_refresh_token,
+  };
+}
+
+export async function getAccessToken(credentials: RefreshTokenConfig) {
+  return (await AuthProvider.getAccessToken(credentials)).access_token;
+}

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -1,4 +1,9 @@
-import { AuthProvider, RefreshTokenConfig } from '@spotifly/core/provider';
+import {
+  AuthProvider,
+  RefreshTokenConfig,
+  RequestError,
+} from '@spotifly/core/provider';
+import { colors } from '@spotifly/utils';
 import { existsSync, readFileSync } from 'fs';
 import ini from 'ini';
 import os from 'os';
@@ -44,5 +49,14 @@ export function credentialsFromConfig(
 }
 
 export async function getAccessToken(credentials: RefreshTokenConfig) {
-  return (await AuthProvider.getAccessToken(credentials)).access_token;
+  return AuthProvider.getAccessToken(credentials);
+}
+
+export function logError(error: unknown) {
+  if (error instanceof RequestError) {
+    console.error(colors.red(`Error: ${error.message}`));
+    console.error(error.response?.data);
+  } else if (error instanceof Error) {
+    console.error(colors.red(`Error: ${error.message}`));
+  }
 }

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -4,12 +4,6 @@ import ini from 'ini';
 import os from 'os';
 import { join } from 'path';
 
-enum ConfigLocation {
-  Home,
-  Current,
-  None,
-}
-
 const configFileName = '.spotifly';
 
 export function profileFromArgv(argv: string[]): string {
@@ -18,26 +12,15 @@ export function profileFromArgv(argv: string[]): string {
   return argv[withProfile + 1];
 }
 
-function configLocaton(): ConfigLocation {
-  return existsSync(join(process.cwd(), configFileName))
-    ? ConfigLocation.Current
-    : existsSync(join(os.homedir(), configFileName))
-    ? ConfigLocation.Home
-    : ConfigLocation.None;
-}
-
 export function readConfig(): string | null {
-  const configLoc = configLocaton();
-
-  if (configLoc === ConfigLocation.None) return null;
+  const curDirConf = join(process.cwd(), configFileName);
+  if (existsSync(curDirConf)) return readFileSync(curDirConf, 'utf-8');
 
   // Fallback dir is home
-  let path = join(os.homedir(), configFileName);
-  // Current directory overrides
-  if (configLoc === ConfigLocation.Current) {
-    path = join(process.cwd(), configFileName);
-  }
-  return readFileSync(path, 'utf-8');
+  const homeDirConf = join(os.homedir(), configFileName);
+  if (existsSync(homeDirConf)) return readFileSync(homeDirConf, 'utf-8');
+
+  return null;
 }
 
 export function credentialsFromConfig(

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -28,6 +28,7 @@ function configLocaton(): ConfigLocation {
 
 export function readConfig(): string | null {
   const configLoc = configLocaton();
+
   if (configLoc === ConfigLocation.None) return null;
 
   // Fallback dir is home

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -97,7 +97,7 @@ describe('CLI', () => {
     });
   });
 
-  test('With auto-token refresh and default profile', async () => {
+  test('With refresh token and default profile', async () => {
     process.argv = ['', '', 'library'];
     configSpy.mockReturnValueOnce(`[default]
       spt_client_id=a02b6c2ef3e7
@@ -107,7 +107,7 @@ describe('CLI', () => {
     expect(mockPkg.callback).toHaveBeenCalledWith(['--token', 'token']);
   });
 
-  test('With auto-token refresh and custom profile', async () => {
+  test('With refresh token and custom profile', async () => {
     process.argv = ['', '', 'library', '--profile', 'test'];
     configSpy.mockReturnValueOnce(`[test]
       spt_client_id=a02b6c2ef3e7
@@ -122,13 +122,28 @@ describe('CLI', () => {
     ]);
   });
 
-  test('With auto-token refresh and invalid profile', async () => {
+  test('With refresh token and invalid credentials', async () => {
+    process.argv = ['', '', 'library'];
+    configSpy.mockReturnValueOnce(`[default]
+      spt_client_id=a02b6c2ef3e7
+      spt_client_secret=4e11b25b6f`);
+    await cli.run();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenLastCalledWith(
+      expect.stringMatching(/Missing or invalid Spotify credentials/)
+    );
+  });
+
+  test('With refresh token and invalid profile', async () => {
     process.argv = ['', '', 'library'];
     configSpy.mockReturnValueOnce(`[test]
       spt_client_id=a02b6c2ef3e7
       spt_client_secret=4e11b25b6f
       spt_refresh_token=AQChZXEeZs0r8wNdLaQmCxtORFIh5j4`);
-    await expect(cli.run()).resolves.toBeUndefined();
+    await cli.run();
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenLastCalledWith(
+      expect.stringMatching(/Profile "default" does not exist/)
+    );
   });
 });

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -27,8 +27,11 @@ const configSpy = jest
   .spyOn(credentialUtils, 'readConfig')
   .mockReturnValue(null);
 
-const consoleSpy = jest
+const consoleInfoSpy = jest
   .spyOn(global.console, 'info')
+  .mockImplementation(jest.fn);
+const consoleErrorSpy = jest
+  .spyOn(global.console, 'error')
   .mockImplementation(jest.fn);
 
 beforeEach(() => {
@@ -47,8 +50,8 @@ describe('CLI', () => {
       process.argv = processArgs;
       await cli.run();
       expect(mockPkg.callback).not.toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
-      expect(consoleSpy.mock.calls[0][0]).toMatch(
+      expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+      expect(consoleInfoSpy.mock.calls[0][0]).toMatch(
         /(Spotifly|@spotifly\/cli) v\d.\d.\d/g
       );
     });
@@ -87,8 +90,8 @@ describe('CLI', () => {
       process.argv = processArgs;
       await cli.run();
       expect(mockPkg.callback).not.toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
-      expect(consoleSpy.mock.calls[0][0]).toMatch(
+      expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+      expect(consoleInfoSpy.mock.calls[0][0]).toMatch(
         /Unknown argument .*[\s\S]Run 'spotifly --help' for available commands/s
       );
     });
@@ -117,5 +120,15 @@ describe('CLI', () => {
       '--token',
       'token',
     ]);
+  });
+
+  test('With auto-token refresh and invalid profile', async () => {
+    process.argv = ['', '', 'library'];
+    configSpy.mockReturnValueOnce(`[test]
+      spt_client_id=a02b6c2ef3e7
+      spt_client_secret=4e11b25b6f
+      spt_refresh_token=AQChZXEeZs0r8wNdLaQmCxtORFIh5j4`);
+    await expect(cli.run()).resolves.toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,8 @@
   },
   "preconstruct": {
     "entrypoints": [
-      "index.ts"
+      "index.ts",
+      "provider.ts"
     ]
   }
 }

--- a/packages/core/provider/package.json
+++ b/packages/core/provider/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/spotifly-core-provider.cjs.js",
+  "module": "dist/spotifly-core-provider.esm.js"
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,6 @@ export function initialize(authOptions: AuthProviderOptions) {
 
 export type SpotifyClient = ReturnType<typeof initialize>;
 export type { DataCallback, DataPromise, DataResponse } from './types';
-export type { AuthProviderOptions };
 export { isError };
 
 export default {

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { AsyncProvider } from './types';
 
+export { AxiosError as RequestError } from 'axios';
+
 export type AccessTokenConfig = {
   accessToken: string;
 };

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -1,11 +1,11 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { AsyncProvider } from './types';
 
-type AccessTokenConfig = {
+export type AccessTokenConfig = {
   accessToken: string;
 };
 
-type RefreshTokenConfig = {
+export type RefreshTokenConfig = {
   refreshToken: string;
   clientId: string;
   clientSecret: string;
@@ -65,11 +65,11 @@ export class AuthProvider implements AsyncProvider {
   }
 
   private async refreshAccessToken() {
-    const { access_token } = await AuthProvider.getAccessToken(
-      this.auth.clientId,
-      this.auth.clientSecret,
-      this.auth.refreshToken
-    );
+    const { access_token } = await AuthProvider.getAccessToken({
+      clientId: this.auth.clientId,
+      clientSecret: this.auth.clientSecret,
+      refreshToken: this.auth.refreshToken,
+    });
 
     // Access tokens expire after 1 hour.
     this.auth.accessToken = access_token;
@@ -82,11 +82,11 @@ export class AuthProvider implements AsyncProvider {
     );
   }
 
-  public static getAccessToken(
-    clientId: string,
-    clientSecret: string,
-    refreshToken: string
-  ) {
+  public static getAccessToken({
+    clientId,
+    clientSecret,
+    refreshToken,
+  }: RefreshTokenConfig) {
     return axios
       .post<{
         access_token: string;

--- a/website/docs/command-line.mdx
+++ b/website/docs/command-line.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 ## Installing the CLI
 
-Spotifly's wrapper CLI can be installed globally. It ships with the latest versions of all executables from this project. The CLI and all other packages require at least Node 14.
+Spotifly's wrapper CLI can be installed globally. It ships with the latest versions of all executables (as subcommands) from this project. The CLI and all other packages require at least Node 14.
 
 ```bash
 yarn global add @spotifly/cli@latest
@@ -19,8 +19,42 @@ npm install -g @spotifly/cli@latest
 Then:
 
 ```bash
-spotifly [package] [args...]
+spotifly [subcommand] [args...]
 ```
+
+## Configuration and Auto-Authentication
+
+Many CLI operations require an access token to talk to the Spotify API. If you don't want to manually generate one every time you use the CLI, you can _optionally_ create a `.spotifly` config file in your home directory:
+
+```ini
+[default]
+spt_client_id=a02b6c2ef3e7
+spt_client_secret=4e11b25b6f
+spt_refresh_token=AQChZXEeZs0r8wNdLaQmCxtORFIh5j4
+
+[dev]
+spt_client_id=a02b6c2ef3e7
+spt_client_secret=4e11b25b6f
+spt_refresh_token=AQChZXEeZs0r8wNdLaQmCxtORFIh5j4
+```
+
+The CLI automatically looks for this file, uses it to generate an access token and passes it to the subcommand.
+
+:::note
+
+A `.spotifly` config file in the current directory takes precedence over configuration in your home directory.
+
+:::
+
+The INI format allows you to create multiple profiles. Each profile must have the three keys depicted above. A custom profile can be selected by passing the `--profile` flag to any subcommand. If no profile is specified, "default" is used. For example:
+
+```bash
+spotifly [subcommand] --profile dev [...args]
+```
+
+**Why does this require a configuration file? Why can't I just pass my long-term credentials as flags?**
+
+It is a very bad idea to [read secrets from flags](https://clig.dev/#arguments-and-flags). Long story short is that your credentials will leak to other places like your shell history. Hence, only reading from a configuration file is supported.
 
 ## Usage with NPX / Yarn DLX
 

--- a/website/docs/command-line.mdx
+++ b/website/docs/command-line.mdx
@@ -46,15 +46,21 @@ A `.spotifly` config file in the current directory takes precedence over configu
 
 :::
 
+### Using Profiles
+
 The INI format allows you to create multiple profiles. Each profile must have the three keys depicted above. A custom profile can be selected by passing the `--profile` flag to any subcommand. If no profile is specified, "default" is used. For example:
 
 ```bash
 spotifly [subcommand] --profile dev [...args]
 ```
 
-**Why does this require a configuration file? Why can't I just pass my long-term credentials as flags?**
+### Why would you use different profiles?
 
-It is a very bad idea to [read secrets from flags](https://clig.dev/#arguments-and-flags). Long story short is that your credentials will leak to other places like your shell history. Hence, only reading from a configuration file is supported.
+Remember: Spotify refresh tokens are _created for_ a spotify application and _bound to_ a user **and** access scope. Hence, you may have multiple profiles for a single spotify application, whereas the client id and secret are the same. The refresh tokens, however, may be different. You could have a profile for readonly access, another for read/write access, etc.
+
+### Why does this require a configuration file?
+
+_Why can't I just pass my long-term credentials as flags?_ It is a very bad idea to [read secrets from flags](https://clig.dev/#arguments-and-flags). Long story short is that your credentials will leak to other places like your shell history. Hence, only reading from a configuration file is supported.
 
 ## Usage with NPX / Yarn DLX
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -68,6 +68,7 @@ const config = {
         copyright: `Copyright © ${new Date().getFullYear()} Spotifly. Not affiliated with Spotify USA Inc. Built with Docusaurus.`,
       },
       prism: {
+        additionalLanguages: ['ini'],
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4575,8 +4575,11 @@ __metadata:
   resolution: "@spotifly/cli@workspace:packages/cli"
   dependencies:
     "@spotifly/auth-token": "workspace:^"
+    "@spotifly/core": "workspace:^"
     "@spotifly/library": "workspace:^"
     "@spotifly/utils": "workspace:^"
+    "@types/ini": ^1.3.31
+    ini: ^4.1.0
   bin:
     spotifly: bin.js
   languageName: unknown
@@ -5067,6 +5070,13 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: 7a6746d00729b2a9fe9f9dd3453430b099931df879ec8f7a7b5f07b1795f6d99b0512640c45a67390b1e4bacb9401e36824952aeeaf089feba8627a063cf8e00
+  languageName: node
+  linkType: hard
+
+"@types/ini@npm:^1.3.31":
+  version: 1.3.31
+  resolution: "@types/ini@npm:1.3.31"
+  checksum: aca4fed0cd68f6693fd64e1b7d188a9c8c6f5823b2e3501b0570135555d4184d7d0dfba2c1afb3514c94cb21ece732f4467ea98c827d1b1b98716827ac9de680
   languageName: node
   linkType: hard
 
@@ -10358,6 +10368,13 @@ __metadata:
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
+  languageName: node
+  linkType: hard
+
+"ini@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "ini@npm:4.1.0"
+  checksum: 12fc7c1f0a048e37398928f32513b494012b11fcec43fc3ef687445b29d959c548abef6d911686e507199c17c366c5bce7bedf02c3fc32912a71737b8291f6c5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6858,17 +6858,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001335, caniuse-lite@npm:^1.0.30001359":
-  version: 1.0.30001361
-  resolution: "caniuse-lite@npm:1.0.30001361"
-  checksum: 3b56c9b4edf8f0b4a1891b0883f6fc7ab758858f4018d4c98aae474d235405cc2271b83c01af856add322a85df6f748514a7db020cade873ad6356e0a80b940c
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001400":
-  version: 1.0.30001431
-  resolution: "caniuse-lite@npm:1.0.30001431"
-  checksum: bc8ab55cd194e240152946b54bfaff7456180cc018674fc7ed134f4f502192405f6643f422feaa0a5e7cc02b5bac564cfac7771ac6d29f5d129482fcfe335ba1
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001335, caniuse-lite@npm:^1.0.30001359, caniuse-lite@npm:^1.0.30001400":
+  version: 1.0.30001480
+  resolution: "caniuse-lite@npm:1.0.30001480"
+  checksum: c0b40f02f45ee99c73f732a3118028b2ab1544962d473d84f2afcb898a5e3099bd4c45f316ebc466fb1dbda904e86b72695578ca531a0bfa9d6337e7aad1ee2a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Feature PR to enable reading from a `.spotifly` config file (INI format), e.g.:
```ini
[default]
spt_client_id=a02b6c2ef3e7
spt_client_secret=4e11b25b6f
spt_refresh_token=AQChZXEeZs0r8wNdLaQmCxtORFIh5j4
```
If a subcommand requires an access token, it is automatically generated from the config file located in the current directory or the user's home directory (fallback) and passed to the subcommand. An ini profile can optionally be specified. 